### PR TITLE
auf der gruenen Wiese neu aufgesetzt (WIN und LINUX), haufenweise WEL…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,13 +43,13 @@
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
-            <version>2.25.1</version>
+            <version>2.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.glassfish.jersey.containers/jersey-container-servlet -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>
-            <version>2.25.1</version>
+            <version>2.14</version>
         </dependency>
         <!-- loest: MessageBodyWriter not found for media type=application/json
         And then register the JacksonFeature in your Application/ResourceConfig subclass...
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.25.1</version>
+            <version>2.14</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.module</groupId>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>2.25.1</version>
+            <version>2.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
         <dependency>


### PR DESCRIPTION
…D/CDI Fehler, hat offenbar mit der Jersey Version zu tun. Von 2.25.1 runter auf 2.14 und alle Fehler sind weg